### PR TITLE
Conform enums to standard Python formatting

### DIFF
--- a/plusdeck/client.py
+++ b/plusdeck/client.py
@@ -44,8 +44,8 @@ class Command(Enum):
 
     PLAY_A = b"\x01"
     PLAY_B = b"\x02"
-    FAST_A = b"\x03"
-    FAST_B = b"\x04"
+    FAST_FORWARD_A = b"\x03"
+    FAST_FORWARD_B = b"\x04"
     PAUSE = b"\x05"
     STOP = b"\x06"
     EJECT = b"\x08"
@@ -74,8 +74,8 @@ class State(Enum):
     PLAYING_B = 20
     SUBSCRIBED = 21
     PAUSED_B = 22
-    MOVING_FAST_A = 30
-    MOVING_FAST_B = 40
+    FAST_FORWARDING_A = 30
+    FAST_FORWARDING_B = 40
     STOPPED = 50
     EJECTED = 60
     SUBSCRIBING = -1

--- a/plusdeck/client.py
+++ b/plusdeck/client.py
@@ -42,15 +42,15 @@ class SubscriptionError(StateError):
 class Command(Enum):
     """A command for the Plus Deck 2C PC Cassette Deck."""
 
-    PlayA = b"\x01"
-    PlayB = b"\x02"
-    FastForward = b"\x03"
-    Rewind = b"\x04"
-    Pause = b"\x05"
-    Stop = b"\x06"
-    Eject = b"\x08"
-    Subscribe = b"\x0b"
-    Unsubscribe = b"\x0c"
+    PLAY_A = b"\x01"
+    PLAY_B = b"\x02"
+    FAST_A = b"\x03"
+    FAST_B = b"\x04"
+    PAUSE = b"\x05"
+    STOP = b"\x06"
+    EJECT = b"\x08"
+    SUBSCRIBE = b"\x0b"
+    UNSUBSCRIBE = b"\x0c"
 
     @classmethod
     def from_bytes(cls: Type["Command"], buffer: bytes) -> List["Command"]:
@@ -69,18 +69,18 @@ class Command(Enum):
 class State(Enum):
     """The state of the Plus Deck 2C PC Cassette Deck."""
 
-    PlayingA = 0x0A
-    PausedA = 0x0C
-    PlayingB = 0x14
-    Subscribed = 0x15
-    PausedB = 0x16
-    FastForwarding = 0x1E
-    Rewinding = 0x28
-    Stopped = 0x32
-    Ejected = 0x3C
-    Subscribing = -1
-    Unsubscribing = -2
-    Unsubscribed = -3
+    PLAYING_A = 10
+    PAUSED_A = 12
+    PLAYING_B = 20
+    SUBSCRIBED = 21
+    PAUSED_B = 22
+    MOVING_FAST_A = 30
+    MOVING_FAST_B = 40
+    STOPPED = 50
+    EJECTED = 60
+    SUBSCRIBING = -1
+    UNSUBSCRIBING = -2
+    UNSUBSCRIBED = -3
 
     @classmethod
     def from_bytes(cls: Type["State"], buffer: bytes) -> List["State"]:
@@ -131,7 +131,7 @@ class Receiver(asyncio.Queue):
 
             yield state
 
-            if state == State.Unsubscribed:
+            if state == State.UNSUBSCRIBED:
                 self._receiving = False
 
     def close(self) -> None:
@@ -160,7 +160,7 @@ class Client(asyncio.Protocol):
     ):
         _loop = loop if loop else asyncio.get_running_loop()
 
-        self.state: State = State.Unsubscribed
+        self.state: State = State.UNSUBSCRIBED
         self.events: AsyncIOEventEmitter = AsyncIOEventEmitter(_loop)
         self._loop: asyncio.AbstractEventLoop = _loop
         self._connection_made: asyncio.Future[None] = self._loop.create_future()
@@ -173,8 +173,6 @@ class Client(asyncio.Protocol):
         self._transport = transport
         self._connection_made.set_result(None)
 
-
-
     def close(self) -> None:
         if not self._transport:
             raise ConnectionError("Can not close uninitialized connection")
@@ -186,10 +184,10 @@ class Client(asyncio.Protocol):
         if not self._transport:
             raise ConnectionError("Connection has not yet been made.")
 
-        if command == Command.Subscribe:
-            self._on_state(State.Subscribing)
-        elif command == Command.Unsubscribe:
-            self._on_state(State.Unsubscribing)
+        if command == Command.SUBSCRIBE:
+            self._on_state(State.SUBSCRIBING)
+        elif command == Command.UNSUBSCRIBE:
+            self._on_state(State.UNSUBSCRIBING)
 
         self._transport.write(command.value)
 
@@ -209,29 +207,29 @@ class Client(asyncio.Protocol):
         # there are an unspecified number of events, we will need to resort to
         # timeouts.
 
-        if previous == State.Unsubscribing:
-            if not (state == State.PausedA or state == State.PausedB):
+        if previous == State.UNSUBSCRIBING:
+            if not (state == State.PAUSED_A or state == State.PAUSED_B):
                 raise SubscriptionError(f"Unexpected state {state} while unsubscribing")
-            state = State.Unsubscribed
+            state = State.UNSUBSCRIBED
 
-        if previous == State.Unsubscribed and state != State.Subscribing:
+        if previous == State.UNSUBSCRIBED and state != State.SUBSCRIBING:
             raise SubscriptionError(f"Unexpected state {state} while unsubscribed")
 
         self.state = state
 
         if state != previous:
-            if state == State.Subscribed:
+            if state == State.SUBSCRIBED:
                 self.events.emit("subscribed")
 
             self.events.emit("state", state)
 
-            if state == State.Unsubscribed:
+            if state == State.UNSUBSCRIBED:
                 self.events.emit("unsubscribed")
 
             for rcv in list(self._receivers):
                 self._loop.create_task(rcv.put(state))
 
-        if state == State.Unsubscribed:
+        if state == State.UNSUBSCRIBED:
             for rcv in list(self._receivers):
                 rcv.close()
 
@@ -295,14 +293,14 @@ class Client(asyncio.Protocol):
         rcv = Receiver(client=self, maxsize=maxsize)
         self._receivers.add(rcv)
 
-        if self.state == State.Unsubscribed:
+        if self.state == State.UNSUBSCRIBED:
             # Automatically subscribe
-            fut = self.wait_for(State.Subscribed)
-            self.send(Command.Subscribe)
+            fut = self.wait_for(State.SUBSCRIBED)
+            self.send(Command.SUBSCRIBE)
             await fut
-        elif self.state == State.Subscribing:
+        elif self.state == State.SUBSCRIBING:
             # Wait for in-progress subscription to complete
-            await self.wait_for(State.Subscribed)
+            await self.wait_for(State.SUBSCRIBED)
         else:
             # Must already be subscribed
             pass
@@ -319,14 +317,14 @@ class Client(asyncio.Protocol):
 
         # If already unsubscribing or unsubscribed, we just need to let
         # events take their course
-        if self.state in {State.Unsubscribing, State.Unsubscribed}:
+        if self.state in {State.UNSUBSCRIBING, State.UNSUBSCRIBED}:
             return
 
         # Wait until subscribed in order to avoid whacky state
-        if self.state == State.Subscribing:
-            await self.wait_for(State.Subscribed)
+        if self.state == State.SUBSCRIBING:
+            await self.wait_for(State.SUBSCRIBED)
 
-        self.send(Command.Unsubscribe)
+        self.send(Command.UNSUBSCRIBE)
 
     @asynccontextmanager
     async def session(self):

--- a/plusdeck/jupyter.py
+++ b/plusdeck/jupyter.py
@@ -43,8 +43,8 @@ STATES = {
     State.PAUSED_A: "Pause Side A",
     State.PLAYING_B: "Play Side B",
     State.PAUSED_B: "Pause Side B",
-    State.MOVING_FAST_A: "Fast-Forward",
-    State.MOVING_FAST_B: "Rewind",
+    State.FAST_FORWARDING_A: "Fast-Forward A (Rewind B)",
+    State.FAST_FORWARDING_B: "Fast-Forward B (Rewind A)",
     State.STOPPED: "Stop",
     State.EJECTED: "Eject",
     State.SUBSCRIBING: "Hello",
@@ -114,13 +114,13 @@ async def player(client: Client) -> widgets.HBox:
 
     @fast_forward.on_click
     def on_fast_forward(button):
-        client.send(Command.FAST_B)
+        client.send(Command.FAST_FORWARD_B)
 
     rewind = widgets.Button(value=False, description="⏪", tooltip="Rewind")
 
     @rewind.on_click
     def on_rewind(button):
-        client.send(Command.FAST_A)
+        client.send(Command.FAST_FORWARD_A)
 
     power = widgets.Button(value=False, description="⏻", tooltip="Turn On/Off")
 

--- a/plusdeck/jupyter.py
+++ b/plusdeck/jupyter.py
@@ -39,18 +39,18 @@ class ConfigEditor(widgets.VBox):
 
 
 STATES = {
-    State.PlayingA: "Play Side A",
-    State.PausedA: "Pause Side A",
-    State.PlayingB: "Play Side B",
-    State.PausedB: "Pause Side B",
-    State.FastForwarding: "Fast-Forward",
-    State.Rewinding: "Rewind",
-    State.Stopped: "Stop",
-    State.Ejected: "Eject",
-    State.Subscribing: "Hello",
-    State.Subscribed: "Hello",
-    State.Unsubscribing: "Goodbye",
-    State.Unsubscribed: "Off",
+    State.PLAYING_A: "Play Side A",
+    State.PAUSED_A: "Pause Side A",
+    State.PLAYING_B: "Play Side B",
+    State.PAUSED_B: "Pause Side B",
+    State.MOVING_FAST_A: "Fast-Forward",
+    State.MOVING_FAST_B: "Rewind",
+    State.STOPPED: "Stop",
+    State.EJECTED: "Eject",
+    State.SUBSCRIBING: "Hello",
+    State.SUBSCRIBED: "Hello",
+    State.UNSUBSCRIBING: "Goodbye",
+    State.UNSUBSCRIBED: "Off",
 }
 
 
@@ -77,7 +77,7 @@ async def player(client: Client) -> widgets.HBox:
 
     @pause.on_click
     def on_pause(button):
-        client.send(Command.Pause)
+        client.send(Command.PAUSE)
 
     play_a = widgets.Button(
         value=False, description="▶️", tooltip="Play Side A", layout={"width": "45%"}
@@ -85,14 +85,14 @@ async def player(client: Client) -> widgets.HBox:
 
     @play_a.on_click
     def on_play_a(button):
-        client.send(Command.PlayA)
+        client.send(Command.PLAY_A)
 
     play_b = widgets.Button(
         value=False, description="◀️", tooltip="Play Side B", layout={"width": "45%"}
     )
 
     def on_play_b(button):
-        client.send(Command.PlayB)
+        client.send(Command.PLAY_B)
 
     play_b.on_click(on_play_b)
 
@@ -102,31 +102,31 @@ async def player(client: Client) -> widgets.HBox:
 
     @stop.on_click
     def on_stop(button):
-        client.send(Command.Stop)
+        client.send(Command.STOP)
 
     eject = widgets.Button(value=False, description="⏏️", tooltip="Eject")
 
     @eject.on_click
     def on_eject(button):
-        client.send(Command.Eject)
+        client.send(Command.EJECT)
 
     fast_forward = widgets.Button(value=False, description="⏩", tooltip="Fast-Forward")
 
     @fast_forward.on_click
     def on_fast_forward(button):
-        client.send(Command.FastForward)
+        client.send(Command.FAST_B)
 
     rewind = widgets.Button(value=False, description="⏪", tooltip="Rewind")
 
     @rewind.on_click
     def on_rewind(button):
-        client.send(Command.Rewind)
+        client.send(Command.FAST_A)
 
     power = widgets.Button(value=False, description="⏻", tooltip="Turn On/Off")
 
     @power.on_click
     def on_power(button):
-        client.send(Command.Unsubscribe)
+        client.send(Command.UNSUBSCRIBE)
 
     return widgets.HBox(
         [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ import plusdeck.config
 async def client():
     client = Client()
     client._transport = Mock(name="client._transport")
-    client.state = State.Subscribed
+    client.state = State.SUBSCRIBED
     return client
 
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -47,60 +47,60 @@ async def test_commands_and_events():
     async with client.session() as rcv:
         take_action("Put a tape in the deck")
 
-        await rcv.expect(State.Stopped)
+        await rcv.expect(State.STOPPED)
 
-        client.send(Command.Rewind)
+        client.send(Command.FAST_B)
 
-        await rcv.expect(State.Rewinding)
-        await rcv.expect(State.Stopped)
+        await rcv.expect(State.MOVING_FAST_B)
+        await rcv.expect(State.STOPPED)
 
-        client.send(Command.PlayA)
+        client.send(Command.PLAY_A)
 
-        await rcv.expect(State.PlayingA)
+        await rcv.expect(State.PLAYING_A)
 
         check("Did the deck rewind and start playing side A?", "Deck is playing side A")
 
-        client.send(Command.Pause)
+        client.send(Command.PAUSE)
 
-        await rcv.expect(State.PausedA)
+        await rcv.expect(State.PAUSED_A)
 
         check("Did the deck pause?", "Deck is paused on side A")
 
-        client.send(Command.Pause)
+        client.send(Command.PAUSE)
 
-        await rcv.expect(State.PlayingA)
+        await rcv.expect(State.PLAYING_A)
 
         check("Did the deck start playing side A again?", "Deck is playing side A")
 
-        client.send(Command.FastForward)
+        client.send(Command.FAST_A)
 
-        await rcv.expect(State.FastForwarding)
-        await rcv.expect(State.Stopped)
+        await rcv.expect(State.MOVING_FAST_A)
+        await rcv.expect(State.STOPPED)
 
-        client.send(Command.PlayB)
+        client.send(Command.PLAY_B)
 
-        await rcv.expect(State.PlayingB)
+        await rcv.expect(State.PLAYING_B)
 
         check(
             "Did the deck fast-forward and start playing side B?",
             "Deck is playing side B",
         )
 
-        client.send(Command.Pause)
+        client.send(Command.PAUSE)
 
-        await rcv.expect(State.PausedB)
+        await rcv.expect(State.PAUSED_B)
 
         check("Did the deck pause?", "Deck is paused on side A")
 
-        client.send(Command.Pause)
+        client.send(Command.PAUSE)
 
-        await rcv.expect(State.PlayingB)
+        await rcv.expect(State.PLAYING_B)
 
         check("Did the deck start playing side B again?", "Deck is playing side B")
 
-        client.send(Command.Eject)
+        client.send(Command.EJECT)
 
-        await rcv.expect(State.Ejected)
+        await rcv.expect(State.EJECTED)
 
         check("Did the deck eject the tape?", "Deck has ejected")
 

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -49,9 +49,9 @@ async def test_commands_and_events():
 
         await rcv.expect(State.STOPPED)
 
-        client.send(Command.FAST_B)
+        client.send(Command.FAST_FORWARD_B)
 
-        await rcv.expect(State.MOVING_FAST_B)
+        await rcv.expect(State.FAST_FORWARDING_B)
         await rcv.expect(State.STOPPED)
 
         client.send(Command.PLAY_A)
@@ -72,9 +72,9 @@ async def test_commands_and_events():
 
         check("Did the deck start playing side A again?", "Deck is playing side A")
 
-        client.send(Command.FAST_A)
+        client.send(Command.FAST_FORWARD_A)
 
-        await rcv.expect(State.MOVING_FAST_A)
+        await rcv.expect(State.FAST_FORWARDING_A)
         await rcv.expect(State.STOPPED)
 
         client.send(Command.PLAY_B)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -46,10 +46,10 @@ async def test_command(client: Client, command: Command, code: bytes):
         for state in State
         if state
         not in {
-            State.Subscribing,
-            State.Subscribed,
-            State.Unsubscribing,
-            State.Unsubscribed,
+            State.SUBSCRIBING,
+            State.SUBSCRIBED,
+            State.UNSUBSCRIBING,
+            State.UNSUBSCRIBED,
         }
     ],
 )
@@ -57,7 +57,7 @@ async def test_command(client: Client, command: Command, code: bytes):
 async def test_state_events(client: Client, state: State, data: bytes):
     """Emits the state event."""
 
-    client.state = State.Subscribed
+    client.state = State.SUBSCRIBED
 
     received: Optional[State] = None
 
@@ -77,7 +77,7 @@ async def test_subscription_events(client: Client):
     """Emits subscription events."""
 
     # Expecting a subscribed state
-    client.state = State.Subscribing
+    client.state = State.SUBSCRIBING
 
     handler = Mock(name="handler")
     subscribed_handler = Mock(name="subscribe_handler")
@@ -92,32 +92,32 @@ async def test_subscription_events(client: Client):
     # Receive subscribed state
     client.data_received(b"\x15")
 
-    assert client.state == State.Subscribed
+    assert client.state == State.SUBSCRIBED
 
     # Receive playing state
     client.data_received(b"\x0a")
 
-    assert client.state == State.PlayingA
+    assert client.state == State.PLAYING_A
 
     # Expect a pause state to signal unsubscribed
-    client.send(Command.Unsubscribe)
+    client.send(Command.UNSUBSCRIBE)
 
-    assert client.state == State.Unsubscribing
+    assert client.state == State.UNSUBSCRIBING
 
     # Receive pause state
     client.data_received(b"\x0c")
 
-    assert client.state == State.Unsubscribed
+    assert client.state == State.UNSUBSCRIBED
 
     # Did our events fire in order?
     handler.assert_has_calls(
         [
             # Subscribe
             call(),
-            call(State.Subscribed),
-            call(State.PlayingA),
-            call(State.Unsubscribing),
-            call(State.Unsubscribed),
+            call(State.SUBSCRIBED),
+            call(State.PLAYING_A),
+            call(State.UNSUBSCRIBING),
+            call(State.UNSUBSCRIBED),
             # Unsubscribe
             call(),
         ]
@@ -134,7 +134,7 @@ async def test_listens_to(client: Client):
 
     call_count = 0
 
-    @client.listens_to(State.PlayingA)
+    @client.listens_to(State.PLAYING_A)
     def handler():
         nonlocal call_count
         call_count += 1
@@ -142,17 +142,17 @@ async def test_listens_to(client: Client):
     client.data_received(b"\x15\x32")
 
     assert call_count == 0
-    assert client.state == State.Stopped
+    assert client.state == State.STOPPED
 
     client.data_received(b"\x0a")
 
     assert call_count == 1
-    assert client.state == State.PlayingA
+    assert client.state == State.PLAYING_A
 
     client.data_received(b"\x0c")
 
     assert call_count == 1
-    assert client.state == State.PausedA
+    assert client.state == State.PAUSED_A
 
 
 @pytest.mark.asyncio
@@ -165,22 +165,22 @@ async def test_on(client: Client):
         nonlocal call_count
         call_count += 1
 
-    client.on(State.PlayingA, handler)
+    client.on(State.PLAYING_A, handler)
 
     client.data_received(b"\x15\x32")
 
     assert call_count == 0
-    assert client.state == State.Stopped
+    assert client.state == State.STOPPED
 
     client.data_received(b"\x0a")
 
     assert call_count == 1
-    assert client.state == State.PlayingA
+    assert client.state == State.PLAYING_A
 
     client.data_received(b"\x0c")
 
     assert call_count == 1
-    assert client.state == State.PausedA
+    assert client.state == State.PAUSED_A
 
 
 @pytest.mark.asyncio
@@ -189,7 +189,7 @@ async def test_listens_once(client: Client):
 
     call_count = 0
 
-    @client.listens_once(State.PlayingA)
+    @client.listens_once(State.PLAYING_A)
     def handler():
         nonlocal call_count
         call_count += 1
@@ -197,22 +197,22 @@ async def test_listens_once(client: Client):
     client.data_received(b"\x15\x32")
 
     assert call_count == 0
-    assert client.state == State.Stopped
+    assert client.state == State.STOPPED
 
     client.data_received(b"\x0a")
 
     assert call_count == 1
-    assert client.state == State.PlayingA
+    assert client.state == State.PLAYING_A
 
     client.data_received(b"\x0a")
 
     assert call_count == 1
-    assert client.state == State.PlayingA
+    assert client.state == State.PLAYING_A
 
     client.data_received(b"\x0c")
 
     assert call_count == 1
-    assert client.state == State.PausedA
+    assert client.state == State.PAUSED_A
 
 
 @pytest.mark.asyncio
@@ -224,27 +224,27 @@ async def test_once(client: Client):
         nonlocal call_count
         call_count += 1
 
-    client.once(State.PlayingA, handler)
+    client.once(State.PLAYING_A, handler)
 
     client.data_received(b"\x15\x32")
 
     assert call_count == 0
-    assert client.state == State.Stopped
+    assert client.state == State.STOPPED
 
     client.data_received(b"\x0a")
 
     assert call_count == 1
-    assert client.state == State.PlayingA
+    assert client.state == State.PLAYING_A
 
     client.data_received(b"\x0a")
 
     assert call_count == 1
-    assert client.state == State.PlayingA
+    assert client.state == State.PLAYING_A
 
     client.data_received(b"\x0c")
 
     assert call_count == 1
-    assert client.state == State.PausedA
+    assert client.state == State.PAUSED_A
 
 
 @pytest.mark.parametrize(
@@ -254,10 +254,10 @@ async def test_once(client: Client):
         for state in State
         if state
         not in {
-            State.Subscribing,
-            State.Subscribed,
-            State.Unsubscribing,
-            State.Unsubscribed,
+            State.SUBSCRIBING,
+            State.SUBSCRIBED,
+            State.UNSUBSCRIBING,
+            State.UNSUBSCRIBED,
         }
     ],
 )
@@ -277,9 +277,9 @@ async def test_subscribe_when_unsubscribed(client: Client):
     """Waits for subscribed event when subscribing."""
 
     # Ensure starting state is unsubscribed
-    client.state = State.Unsubscribed
+    client.state = State.UNSUBSCRIBED
 
-    # When transport write is called, simulate receiving State.Subscribed
+    # When transport write is called, simulate receiving State.SUBSCRIBED
     def emit_ready(_):
         client.data_received(b"\x15")
 
@@ -295,10 +295,10 @@ async def test_subscribe_when_unsubscribed(client: Client):
     cast(Mock, client._transport.write).assert_called_with(b"\x0b")
 
     # Set the current state
-    assert client.state == State.Subscribed
+    assert client.state == State.SUBSCRIBED
 
 
-@pytest.mark.parametrize("state", [State.Ejected, State.Subscribed])
+@pytest.mark.parametrize("state", [State.EJECTED, State.SUBSCRIBED])
 @pytest.mark.asyncio
 async def test_subscribe_when_subscribed(client: Client, state: State):
     """Creates receiver when already subscribed."""
@@ -320,10 +320,10 @@ async def test_subscribe_when_subscribed(client: Client, state: State):
         for state in State
         if state
         not in {
-            State.Ejected,
-            State.Subscribing,
-            State.Unsubscribing,
-            State.Unsubscribed,
+            State.EJECTED,
+            State.SUBSCRIBING,
+            State.UNSUBSCRIBING,
+            State.UNSUBSCRIBED,
         }
     ],
 )
@@ -331,7 +331,7 @@ async def test_subscribe_when_subscribed(client: Client, state: State):
 async def test_receive_state(client: Client, buffer, state):
     """Receives a state."""
 
-    client.state = State.Ejected
+    client.state = State.EJECTED
 
     rcv = await asyncio.wait_for(client.subscribe(), timeout=TEST_TIMEOUT)
 
@@ -351,10 +351,10 @@ async def test_receive_state(client: Client, buffer, state):
         for state in State
         if state
         not in {
-            State.Ejected,
-            State.Subscribing,
-            State.Unsubscribing,
-            State.Unsubscribed,
+            State.EJECTED,
+            State.SUBSCRIBING,
+            State.UNSUBSCRIBING,
+            State.UNSUBSCRIBED,
         }
     ],
 )
@@ -362,7 +362,7 @@ async def test_receive_state(client: Client, buffer, state):
 async def test_expect_state(client: Client, buffer, state):
     """Expect a state."""
 
-    client.state = State.Ejected
+    client.state = State.EJECTED
 
     rcv = await asyncio.wait_for(client.subscribe(), timeout=TEST_TIMEOUT)
 
@@ -378,7 +378,7 @@ async def test_expect_state(client: Client, buffer, state):
 @pytest.mark.asyncio
 async def test_receive_duplicate_state(client: Client):
     """Receives a state once."""
-    client.state = State.Ejected
+    client.state = State.EJECTED
 
     rcv = await asyncio.wait_for(client.subscribe(), timeout=TEST_TIMEOUT)
 
@@ -388,8 +388,8 @@ async def test_receive_duplicate_state(client: Client):
 
     client.data_received(b"\x32")
 
-    assert (await fut) == State.Stopped
-    assert client.state == State.Stopped
+    assert (await fut) == State.STOPPED
+    assert client.state == State.STOPPED
 
     fut2 = asyncio.wait_for(rcv.get(), timeout=TEST_TIMEOUT)
 
@@ -398,14 +398,14 @@ async def test_receive_duplicate_state(client: Client):
     with pytest.raises(asyncio.TimeoutError):
         await fut2
 
-    assert client.state == State.Stopped
+    assert client.state == State.STOPPED
 
 
 @pytest.mark.asyncio
 async def test_many_receivers(client: Client):
     """Juggles many receivers."""
 
-    client.state = State.Unsubscribed
+    client.state = State.UNSUBSCRIBED
 
     def emit_ready(_):
         client.data_received(b"\x15")
@@ -413,7 +413,7 @@ async def test_many_receivers(client: Client):
     assert client._transport is not None
     cast(Mock, client._transport.write).side_effect = emit_ready
 
-    ready = client.wait_for(State.Subscribed, timeout=TEST_TIMEOUT)
+    ready = client.wait_for(State.SUBSCRIBED, timeout=TEST_TIMEOUT)
 
     # Create first receiver before subscribing
     rcv1 = await asyncio.wait_for(client.subscribe(), timeout=TEST_TIMEOUT)
@@ -431,7 +431,7 @@ async def test_many_receivers(client: Client):
     assert rcv1 in set(client.receivers())
     assert rcv2 in set(client.receivers())
 
-    ejected = client.wait_for(State.Ejected, timeout=TEST_TIMEOUT)
+    ejected = client.wait_for(State.EJECTED, timeout=TEST_TIMEOUT)
     client.data_received(b"\x3c")
     await ejected
 
@@ -441,20 +441,20 @@ async def test_many_receivers(client: Client):
     state1c = await asyncio.wait_for(rcv1.get(), timeout=TEST_TIMEOUT)
 
     assert [state1a, state1b, state1c] == [
-        State.Subscribing,
-        State.Subscribed,
-        State.Ejected,
+        State.SUBSCRIBING,
+        State.SUBSCRIBED,
+        State.EJECTED,
     ]
 
     # Should have one state from second receiver
     state2 = await asyncio.wait_for(rcv2.get(), timeout=TEST_TIMEOUT)
 
-    assert state2 == State.Ejected
+    assert state2 == State.EJECTED
 
 
 @pytest.mark.asyncio
 async def test_close_receiver(client: Client):
-    client.state = State.Ejected
+    client.state = State.EJECTED
 
     rcv = await asyncio.wait_for(client.subscribe(), timeout=TEST_TIMEOUT)
 
@@ -466,30 +466,30 @@ async def test_close_receiver(client: Client):
 
 
 @pytest.mark.parametrize(
-    "buffer", [state.to_bytes() for state in {State.PausedA, State.PausedB}]
+    "buffer", [state.to_bytes() for state in {State.PAUSED_A, State.PAUSED_B}]
 )
 @pytest.mark.asyncio
 async def test_unsubscribe(client: Client, buffer):
     """Unsubscribe a subscribed client."""
 
-    client.state = State.Ejected
+    client.state = State.EJECTED
 
     rcv = await asyncio.wait_for(client.subscribe(), timeout=TEST_TIMEOUT)
 
     assert rcv in set(client.receivers())
 
-    fut_wait_for = client.wait_for(State.Unsubscribed, timeout=TEST_TIMEOUT)
+    fut_wait_for = client.wait_for(State.UNSUBSCRIBED, timeout=TEST_TIMEOUT)
     fut_get1 = asyncio.wait_for(rcv.get(), timeout=TEST_TIMEOUT)
     fut_get2 = asyncio.wait_for(rcv.get(), timeout=TEST_TIMEOUT)
 
-    client.send(Command.Unsubscribe)
+    client.send(Command.UNSUBSCRIBE)
     client.data_received(buffer)
 
     assert len(client.receivers()) == 0
 
     await fut_wait_for
-    assert (await fut_get1) == State.Unsubscribing
-    assert (await fut_get2) == State.Unsubscribed
+    assert (await fut_get1) == State.UNSUBSCRIBING
+    assert (await fut_get2) == State.UNSUBSCRIBED
 
     with pytest.raises(asyncio.TimeoutError):
         await asyncio.wait_for(rcv.get(), timeout=TEST_TIMEOUT)
@@ -502,11 +502,11 @@ async def test_unsubscribe(client: Client, buffer):
         for state in State
         if state
         not in {
-            State.PausedA,
-            State.PausedB,
-            State.Subscribing,
-            State.Unsubscribing,
-            State.Unsubscribed,
+            State.PAUSED_A,
+            State.PAUSED_B,
+            State.SUBSCRIBING,
+            State.UNSUBSCRIBING,
+            State.UNSUBSCRIBED,
         }
     ],
 )
@@ -514,13 +514,13 @@ async def test_unsubscribe(client: Client, buffer):
 async def test_failed_unsubscribe(client: Client, state: State):
     """Raises an error if client fails to unsubscribe."""
 
-    client.state = State.Unsubscribing
+    client.state = State.UNSUBSCRIBING
 
     with pytest.raises(SubscriptionError):
         client.data_received(state.to_bytes())
 
 
-@pytest.mark.parametrize("state", [State.Unsubscribing, State.Unsubscribed])
+@pytest.mark.parametrize("state", [State.UNSUBSCRIBING, State.UNSUBSCRIBED])
 @pytest.mark.asyncio
 async def test_unsubscribe_when_unsubscribed(client: Client, state: State):
     """Unsubscribes when already unsubscribed."""
@@ -532,9 +532,9 @@ async def test_unsubscribe_when_unsubscribed(client: Client, state: State):
 
 @pytest.mark.asyncio
 async def test_unsubscribe_when_unsubscribing(client: Client):
-    """Unsubscribes when already unsubscribed."""
+    """Unsubscribes when already unsubscribing."""
 
-    client.state = State.Subscribing
+    client.state = State.SUBSCRIBING
 
     fut = client.unsubscribe()
 
@@ -548,13 +548,13 @@ async def test_unsubscribe_when_unsubscribing(client: Client):
 
 
 @pytest.mark.parametrize(
-    "buffer", [state.to_bytes() for state in {State.PausedA, State.PausedB}]
+    "buffer", [state.to_bytes() for state in {State.PAUSED_A, State.PAUSED_B}]
 )
 @pytest.mark.asyncio
 async def test_iter_receiver(client: Client, buffer: bytes):
     """Iterates a receiver."""
 
-    client.state = State.Ejected
+    client.state = State.EJECTED
 
     rcv = await asyncio.wait_for(client.subscribe(), timeout=TEST_TIMEOUT)
 
@@ -565,10 +565,10 @@ async def test_iter_receiver(client: Client, buffer: bytes):
     client.data_received(b"\x0a")
 
     # Close the connection
-    client.send(Command.Unsubscribe)
+    client.send(Command.UNSUBSCRIBE)
     client.data_received(buffer)
 
-    states = [State.Unsubscribed, State.Unsubscribing, State.PlayingA, State.Stopped]
+    states = [State.UNSUBSCRIBED, State.UNSUBSCRIBING, State.PLAYING_A, State.STOPPED]
 
     async def iterate():
         async for state in rcv:
@@ -583,11 +583,11 @@ async def test_iter_receiver(client: Client, buffer: bytes):
 
 @pytest.mark.asyncio
 async def test_session_queue(client: Client):
-    client.state = State.Unsubscribed
+    client.state = State.UNSUBSCRIBED
 
-    received = [State.PausedA, State.PlayingA, State.Subscribed]
+    received = [State.PAUSED_A, State.PLAYING_A, State.SUBSCRIBED]
 
-    # When transport write is called, simulate receiving State.Subscribed
+    # When transport write is called, simulate receiving State.SUBSCRIBED
     def emit_data(_):
         client.data_received(received.pop().to_bytes())
 
@@ -598,10 +598,10 @@ async def test_session_queue(client: Client):
     state2: Optional[State] = None
     state3: Optional[State] = None
 
-    unsubbed = client.wait_for(State.Unsubscribed)
+    unsubbed = client.wait_for(State.UNSUBSCRIBED)
 
     async with client.session() as rcv:
-        client.send(Command.PlayA)
+        client.send(Command.PLAY_A)
 
         state1 = await asyncio.wait_for(rcv.get(), timeout=TEST_TIMEOUT)
         state2 = await asyncio.wait_for(rcv.get(), timeout=TEST_TIMEOUT)
@@ -611,26 +611,26 @@ async def test_session_queue(client: Client):
 
     cast(Mock, client._transport.write).assert_has_calls(
         [
-            call(Command.Subscribe.to_bytes()),
-            call(Command.PlayA.to_bytes()),
-            call(Command.Unsubscribe.to_bytes()),
+            call(Command.SUBSCRIBE.to_bytes()),
+            call(Command.PLAY_A.to_bytes()),
+            call(Command.UNSUBSCRIBE.to_bytes()),
         ]
     )
 
     assert [state1, state2, state3] == [
-        State.Subscribing,
-        State.Subscribed,
-        State.PlayingA,
+        State.SUBSCRIBING,
+        State.SUBSCRIBED,
+        State.PLAYING_A,
     ]
 
 
 @pytest.mark.asyncio
 async def test_session_iterator(client: Client):
-    client.state = State.Unsubscribed
+    client.state = State.UNSUBSCRIBED
 
-    received = [State.PausedA, State.PlayingA, State.Subscribed]
+    received = [State.PAUSED_A, State.PLAYING_A, State.SUBSCRIBED]
 
-    # When transport write is called, simulate receiving State.Subscribed
+    # When transport write is called, simulate receiving State.SUBSCRIBED
     def emit_data(_):
         client.data_received(received.pop().to_bytes())
 
@@ -639,10 +639,10 @@ async def test_session_iterator(client: Client):
 
     states: List[State] = []
 
-    unsubbed = client.wait_for(State.Unsubscribed)
+    unsubbed = client.wait_for(State.UNSUBSCRIBED)
 
     async with client.session() as rcv:
-        client.send(Command.PlayA)
+        client.send(Command.PLAY_A)
 
         async for state in rcv:
             states.append(state)
@@ -653,14 +653,14 @@ async def test_session_iterator(client: Client):
 
     cast(Mock, client._transport.write).assert_has_calls(
         [
-            call(Command.Subscribe.to_bytes()),
-            call(Command.PlayA.to_bytes()),
-            call(Command.Unsubscribe.to_bytes()),
+            call(Command.SUBSCRIBE.to_bytes()),
+            call(Command.PLAY_A.to_bytes()),
+            call(Command.UNSUBSCRIBE.to_bytes()),
         ]
     )
 
     assert states == [
-        State.Subscribing,
-        State.Subscribed,
-        State.PlayingA,
+        State.SUBSCRIBING,
+        State.SUBSCRIBED,
+        State.PLAYING_A,
     ]


### PR DESCRIPTION
The enums were named using TypeScript conventions. I realized this was a mistake, and wanted to address it. It's a simple change, but making a PR for easier review.