### PR TITLE
Configurence

### DIFF
--- a/Player.ipynb
+++ b/Player.ipynb
@@ -9,7 +9,7 @@
    "source": [
     "%autoawait asyncio\n",
     "\n",
-    "from plusdeck.config import Config\n",
+    "from plusdeck.config import APP_NAME, Config\n",
     "from plusdeck.client import create_connection\n",
     "from plusdeck.jupyter import ConfigEditor, player"
    ]
@@ -21,7 +21,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "config = Config.from_file(load_environment=True)"
+    "config = Config.from_file(APP_NAME, load_environment=True)"
    ]
   },
   {

--- a/plusdeck/config.py
+++ b/plusdeck/config.py
@@ -1,17 +1,5 @@
-from dataclasses import asdict, dataclass, field, fields, replace
-import os
-import os.path
-from typing import Any, Dict, Optional, Type
-
-from appdirs import user_config_dir
+from configurence import config, field
 from serial.tools.list_ports import comports
-import yaml
-
-try:
-    from yaml import CDumper as Dumper
-    from yaml import CLoader as Loader
-except ImportError:
-    from yaml import Dumper, Loader
 
 """
 Configuration management for the Plus Deck 2C PC Cassette Deck. The client
@@ -22,82 +10,16 @@ configuring the ipywidgets player.
 APP_NAME = "plusdeck"
 
 
-def default_file() -> str:
-    """Get the default file path for the Plus Deck 2C client config."""
-
-    return os.path.join(user_config_dir(APP_NAME), f"{APP_NAME}.yaml")
-
-
 def default_port() -> str:
     """Get a default serial port."""
 
     return comports(include_links=True)[0].device
 
 
-def _metadata(env_var: Optional[str] = None) -> Dict[str, Any]:
-    return dict(env_var=env_var)
-
-
-def _from_environment() -> Dict[str, Any]:
-    env: Dict[str, Any] = dict()
-    for f in fields(Config):
-        if f.metadata and "env_var" in f.metadata:
-            if f.metadata["env_var"] in os.environ:
-                env[f.name] = os.environ[f.metadata["env_var"]]
-    return env
-
-
-@dataclass
+@config
 class Config:
     """A config for the Plus Deck 2C PC Cassette Deck."""
 
     port: str = field(
-        default_factory=default_port, metadata=_metadata(env_var="PLUSDECK_PORT")
+        default_factory=default_port, env_var="PLUSDECK_PORT"
     )
-    file: Optional[str] = None
-
-    @classmethod
-    def from_environment(cls: Type["Config"]) -> "Config":
-        """Load a config from the environment."""
-
-        return cls(**_from_environment())
-
-    @classmethod
-    def from_file(
-        cls: Type["Config"],
-        file: Optional[str] = None,
-        load_environment: bool = False,
-        create_file: bool = False,
-    ) -> "Config":
-        """Load a config from a file."""
-
-        _file: str = file or os.environ.get("PLUSDECK_CONFIG", default_file())
-
-        found_file = False
-        kwargs = dict(file=_file)
-        try:
-            with open(_file, "r") as f:
-                found_file = True
-                kwargs.update(yaml.load(f, Loader=Loader))
-        except FileNotFoundError:
-            pass
-
-        if load_environment:
-            kwargs.update(_from_environment())
-
-        config = cls(**kwargs)
-
-        if not found_file and create_file:
-            config.to_file()
-
-        return config
-
-    def to_file(self, file: Optional[str] = None) -> "Config":
-        """Save the config to a file."""
-
-        file = file or self.file or default_file()
-
-        with open(file, "w") as f:
-            yaml.dump(asdict(self), f, Dumper=Dumper)
-
-        return replace(self, file=file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ keywords = []
 license = { text = "MIT" }
 dependencies = [
   "appdirs",
+  "configurence",
   "ipywidgets",
   "pyee",
   "pyserial",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,17 @@
 #    pip-compile --output-file=requirements.txt pyproject.toml
 #
 appdirs==1.4.4
-    # via plusdeck (pyproject.toml)
+    # via
+    #   configurence
+    #   plusdeck (pyproject.toml)
 asttokens==2.4.1
     # via stack-data
+click==8.1.8
+    # via configurence
 comm==0.2.1
     # via ipywidgets
+configurence==1.0.0
+    # via plusdeck (pyproject.toml)
 decorator==5.1.1
     # via ipython
 executing==2.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,7 +9,9 @@ anyio==4.3.0
     #   httpx
     #   jupyter-server
 appdirs==1.4.4
-    # via plusdeck (pyproject.toml)
+    # via
+    #   configurence
+    #   plusdeck (pyproject.toml)
 appnope==0.1.4
     # via ipykernel
 argon2-cffi==23.1.0
@@ -52,6 +54,7 @@ charset-normalizer==3.3.2
 click==8.1.7
     # via
     #   black
+    #   configurence
     #   mkdocs
     #   mkdocstrings
 colorama==0.4.6
@@ -62,6 +65,8 @@ comm==0.2.1
     # via
     #   ipykernel
     #   ipywidgets
+configurence==1.0.0
+    # via plusdeck (pyproject.toml)
 debugpy==1.8.1
     # via ipykernel
 decorator==5.1.1


### PR DESCRIPTION
Draft to do up the configuration library.

A serious wart with the API is that app name has to be passed into the `load_file` API. I should find a sensible way to set that in the decorator.

Something I really don't like is that the config is typed `Any`. That's mostly because Python doesn't support intersection types. I don't know a great way around that.

Tests have not been updated. Some of them can be ported to configurence, others may be specific to plusdeck.