### PR TITLE
Systemd support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
   - `plusdeck.dbus.DbusClient` dbus client class
   - `plusdeckd` dbus service CLI
   - `plusdeckctl` dbus client CLI
+  - systemd unit for `plusdeckd`
+- `python-plusdeck` COPR package spec
+- `plusdeck` COPR package spec
+  - Depends on `python-plusdeck` COPR package
+  - Includes systemd unit for `plusdeckd`
+- Tito based release tagging
+- GitHub release tarball
 - Improved documentation
 
 2025/01/26 Version 2.0.0

--- a/copr/plusdeck.yml
+++ b/copr/plusdeck.yml
@@ -1,0 +1,13 @@
+apiVersion: coprctl/v1alpha1
+kind: package-scm
+metadata:
+  name: plusdeck
+spec:
+  auto_rebuild: true
+  ownername: jfhbrook
+  projectname: joshiverse
+  clone-url: https://github.com/jfhbrook/plusdeck
+  commit: null
+  spec: plusdeck.spec
+  type: git
+  method: tito

--- a/copr/python-plusdeck.yml
+++ b/copr/python-plusdeck.yml
@@ -1,0 +1,13 @@
+apiVersion: coprctl/v1alpha1
+kind: package-pypi
+metadata:
+  name: python-plusdeck
+spec:
+  auto_rebuild: true
+  projectname: jfhbrook/joshiverse
+  packagename: plusdeck
+  packageversion: 2.0.0
+  pythonversions:
+    - "3"
+  spec-generator: pyp2spec
+  template: ""

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,60 @@
 # Development
 
-This section has some *very* light notes on how I'm managing development for this library.
+## Dependencies
 
-I use `uv` for managing dependencies, but also compile `requirements.txt` and `requirements_dev.txt` files that one can use instead. I also use `just` for task running, but if you don't have it installed you can run the commands manually.
+### Development
 
-This library has somewhat comprehensive unit test coverage through `pytest`. Additionally, it has an interactive integration test suite, using a bespoke test framework, which can be run with `just integration`.
+- [just](https://github.com/casey/just)
+  - Alternatively, can run commands manually
+- [uv](https://github.com/astral-sh/uv)
+  - Alternatively, can use `requirements_dev.txt` and run commands manually
+- [shellcheck](https://github.com/koalaman/shellcheck)
+- [npx](https://docs.npmjs.com/cli/v8/commands/npx/) for running `pyright`
+
+### Publishing
+
+- COPR tools
+  - [coprctl](https://github.com/jfhbrook/public/tree/main/coprctl)
+    - MacOS: `brew install jfhbrook/joshiverse/coprctl`
+  - [tito](https://github.com/rpm-software-management/tito)
+    - MacOS: `brew install jfhbrook/joshiverse/tito`
+  - [COPR CLI](https://developer.fedoraproject.org/deployment/copr/copr-cli.html)
+    - MacOS: `brew install jfhbrook/joshiverse/copr`
+  - MacOS: [Docker](https://www.docker.com/)
+- [yq](https://github.com/mikefarah/yq)
+- [gomplate](https://github.com/hairyhenderson/gomplate)
+
+## Common Tasks
+
+### Setup
+
+- `install` - Install dependencies
+- `update` - Update all dependencies
+- `upgrade` - Update all dependencies and rebuild the environment
+
+### Quality Assurance
+
+- `default` - Format, run checks and tests, and lint
+- `format` - Format Python files with `black`
+- `check` - Check types with `pyright`
+- `test` - Run unit tests
+- `snap` - Update snapshots for unit tests
+- `integration` - Run integration tests (need a real Plus Deck 2C)
+- `lint` - Lint the project
+
+### Interactive
+
+- `run` - Thin wrapper around `uv run`
+- `start` - Run `plusdeck` CLI
+- `jupyterlab` - Run jupyterlab
+- `shell` - Start a bash shell with a sourced virtualenv
+
+### Other
+
+- `compile` - Compile `requirements.txt` and `requirements_dev.txt`
+- `docs` - Serve the mkdocs documentation
+- `publish` - Run all publish tasks
+
+## CHANGELOG.md
+
+When submitting features, be sure to update the changelog!

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@
 pip install plusdeck
 ```
 
-To additionally install support for DBus, run:
+To install support for DBus, run:
 
 ```sh
 pip install plusdeck[dbus]

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,9 +6,15 @@
 pip install plusdeck
 ```
 
+To additionally install support for DBus, run:
+
+```sh
+pip install plusdeck[dbus]
+```
+
 In addition, I have a Fedora package on COPR, which can be installed like so:
 
 ```sh
 sudo dnf copr enable jfhbrook/joshiverse
-sudo dnf install python-plusdeck
+sudo dnf install plusdeck
 ```

--- a/justfile
+++ b/justfile
@@ -154,6 +154,14 @@ generate-spec:
 copr-update-version:
   VERSION="$(./scripts/version.py)" yq -i '.spec.packageversion = strenv(VERSION)' copr/python-plusdeck.yml
 
+# Commit generated files
+commit-generated-files:
+  git add requirements.txt
+  git add requirements_dev.txt
+  git add plusdeck.spec
+  git add ./copr
+  git commit -m 'Update generated files'
+
 # Fail if there are uncommitted files
 check-dirty:
   ./scripts/is-dirty.sh
@@ -196,11 +204,11 @@ build-copr package:
 
 # Publish the release on PyPI, GitHub and Copr
 publish:
-  # Update requirements files
+  # Generate files and commit
   @just compile
-  # Update versions to match pyproject.toml
   @just generate-spec
   @just copr-update-version
+  @just commit-generated-files
   # Ensure git is in a good state
   @just check-main-branch
   @just check-dirty

--- a/justfile
+++ b/justfile
@@ -1,5 +1,9 @@
 set dotenv-load := true
 
+# Generally this is '1', but may be incremented if a versioned package release
+# is broken.
+PATCH := "1"
+
 # By default, run checks and tests, then format and lint
 default:
   if [ ! -d venv ]; then just install; fi
@@ -12,15 +16,15 @@ default:
 # Installing, updating and upgrading dependencies
 #
 
-_venv:
+venv:
   if [ ! -d .venv ]; then uv venv; fi
 
-_clean-venv:
+clean-venv:
   rm -rf .venv
 
 # Install all dependencies
 install:
-  @just _venv
+  @just venv
   if [[ "$(uname -s)" == Linux ]]; then uv sync --dev --extra dbus; else uv sync --dev; fi
   uv pip install -e .
 
@@ -33,8 +37,8 @@ upgrade:
   if [ -d venv ]; then just update && just check && just _upgrade; else just update; fi
 
 _upgrade:
-  @just _clean-venv
-  @just _venv
+  @just clean-venv
+  @just venv
   @just install
 
 # Generate locked requirements files based on dependencies in pyproject.toml
@@ -43,7 +47,7 @@ compile:
   cp requirements.txt requirements_dev.txt
   python3 -c 'import toml; print("\n".join(toml.load(open("pyproject.toml"))["dependency-groups"]["dev"]))' >> requirements_dev.txt
 
-_clean-compile:
+clean-compile:
   rm -f requirements.txt
   rm -f requirements_dev.txt
 
@@ -80,18 +84,18 @@ check:
 # Run tests with pytest
 test:
   uv run pytest -vvv ./tests
-  @just _clean-test
+  @just clean-test
 
 # Update snapshots
 snap:
   uv run pytest --snapshot-update ./tests
-  @just _clean-test
+  @just clean-test
 
 # Run integration tests (for what they are)
 integration:
   uv run python ./tests/integration.py
 
-_clean-test:
+clean-test:
   rm -f pytest_runner-*.egg
   rm -rf tests/__pycache__
 
@@ -100,7 +104,7 @@ tox:
   uv run tox
   @just _clean-tox
 
-_clean-tox:
+clean-tox:
   rm -rf .tox
 
 #
@@ -137,18 +141,87 @@ build-docs:
 build:
   uv build
 
-_clean-build:
+# Clean the build
+clean-build:
   rm -rf dist
 
-# Tag the release in git
-tag:
-  uv run git tag -a "$(python3 -c 'import toml; print(toml.load(open("pyproject.toml", "r"))["project"]["version"])')" -m "Release $(python3 -c 'import toml; print(toml.load(open("pyproject.toml", "r"))["project"]["version"])')"
+# Generate plusdeck.spec
+generate-spec:
+  ./scripts/generate-spec.sh "$(./scripts/version.py)" '{{ PATCH }}'
 
-publish: build
-  uv publish
+# Update the package version in ./copr/python-plusdeck.yml
+copr-update-version:
+  VERSION="$(./scripts/version.py)" yq -i '.spec.packageversion = strenv(VERSION)' copr/python-plusdeck.yml
+
+# Fail if there are uncommitted files
+check-dirty:
+  ./scripts/is-dirty.sh
+
+# Fail if not on the main branch
+check-main-branch:
+  ./scripts/is-main-branch.sh
+
+# Tag the release with tito
+tag:
+  tito tag --use-version "$(./scripts/version.py)"
+
+# Bundle the package for GitHub release
+bundle-release:
+  ./scripts/bundle.sh "$(./scripts/version.py)"
+
+# Clean up the release package
+clean-release:
+  rm -f "plusdeck-$(./scripts/version.py).tar.gz"
+
+# Push main and tags
+push:
+  git push origin main --follow-tags
+
+# Publish package to PyPI
+publish-pypi: build
+  uv publish -u __token__
+
+# Create a GitHub release
+gh-release:
+  bash ./scripts/release.sh "$(python ./scripts/get-version.py)" '{{ PATCH }}'
+
+# Apply a COPR package configuration
+apply-copr package:
+  coprctl apply -f ./copr/{{ package }}.yml
+
+# Build a COPR package
+build-copr package:
+  copr build-package jfhbrook/joshiverse --name '{{ package }}'
+
+# Publish the release on PyPI, GitHub and Copr
+publish:
+  # Update requirements files
+  @just compile
+  # Update versions to match pyproject.toml
+  @just generate-spec
+  @just copr-update-version
+  # Ensure git is in a good state
+  @just check-main-branch
+  @just check-dirty
+  # Tag and push
+  @just tag
+  @just push
+  # Build package and bundle release
+  @just clean-build
+  @just clean-release
+  @just build
+  @just bundle-release
+  # Publish package and release
+  @just gh-release
+  @just publish-pypi
+  # Update packages on COPR
+  @just apply-copr python-plusdeck
+  @just apply-copr plusdeck
+  @just build-copr python-plusdeck
+  @just build-copr plusdeck
 
 # Clean up loose files
-clean: _clean-venv _clean-compile _clean-test _clean-tox
+clean: clean-venv clean-compile clean-test clean-build clean-release clean-tox
   rm -rf plusdeck.egg-info
   rm -f plusdeck/*.pyc
   rm -rf plusdeck/__pycache__

--- a/justfile
+++ b/justfile
@@ -163,7 +163,7 @@ check-main-branch:
 
 # Tag the release with tito
 tag:
-  tito tag --use-version "$(./scripts/version.py)"
+  tito tag --use-version "$(./scripts/version.py)" --changelog="$(./scripts/changelog-entry.py "$(./scripts/version.py)")"
 
 # Bundle the package for GitHub release
 bundle-release:

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ set dotenv-load := true
 
 # Generally this is '1', but may be incremented if a versioned package release
 # is broken.
-PATCH := "1"
+RELEASE := "1"
 
 # By default, run checks and tests, then format and lint
 default:
@@ -148,7 +148,7 @@ clean-build:
 
 # Generate plusdeck.spec
 generate-spec:
-  ./scripts/generate-spec.sh "$(./scripts/version.py)" '{{ PATCH }}'
+  ./scripts/generate-spec.sh "$(./scripts/version.py)" '{{ RELEASE }}'
 
 # Update the package version in ./copr/python-plusdeck.yml
 copr-update-version:
@@ -192,7 +192,7 @@ publish-pypi: build
 
 # Create a GitHub release
 gh-release:
-  bash ./scripts/release.sh "$(python ./scripts/get-version.py)" '{{ PATCH }}'
+  bash ./scripts/release.sh "$(python ./scripts/get-version.py)" '{{ RELEASE }}'
 
 # Apply a COPR package configuration
 apply-copr package:

--- a/justfile
+++ b/justfile
@@ -172,7 +172,7 @@ check-main-branch:
 
 # Tag the release with tito
 tag:
-  tito tag --use-version "$(./scripts/version.py)" --changelog="$(./scripts/changelog-entry.py "$(./scripts/version.py)")"
+  VERSION="$(./scripts/version.py)" tito tag --use-version "${VERSION}" --changelog="$(./scripts/changelog-entry.py "${VERSION}")"
 
 # Bundle the package for GitHub release
 bundle-release:

--- a/justfile
+++ b/justfile
@@ -152,7 +152,7 @@ generate-spec:
 
 # Update the package version in ./copr/python-plusdeck.yml
 copr-update-version:
-  VERSION="$(./scripts/version.py)" yq -i '.spec.packageversion = strenv(VERSION)' copr/python-plusdeck.yml
+  VERSION="$(./scripts/version.py)" yq -i '.spec.packageversion = strenv(VERSION)' ./copr/python-plusdeck.yml
 
 # Commit generated files
 commit-generated-files:

--- a/justfile
+++ b/justfile
@@ -69,13 +69,14 @@ start *argv:
 
 # Format with black and isort
 format:
-  uv run black './plusdeck' ./tests
-  uv run isort --settings-file . './plusdeck' ./tests
+  uv run black './plusdeck' ./tests ./scripts
+  uv run isort --settings-file . './plusdeck' ./tests ./scripts
 
 # Lint with flake8
 lint:
-  uv run flake8 './plusdeck' ./tests
+  uv run flake8 './plusdeck' ./tests ./scripts
   uv run validate-pyproject ./pyproject.toml
+  shellcheck ./scripts/*.sh
 
 # Check type annotations with pyright
 check:

--- a/plusdeck.spec
+++ b/plusdeck.spec
@@ -1,0 +1,35 @@
+Name: plusdeck
+Version: 2.0.0
+Release: 1%{?dist}
+License: MPL-2.0
+Summary: Serial client and Linux service for Plus Deck 2C PC Cassette Deck
+
+URL: https://github.com/jfhbrook/plusdeck
+Source0: %{name}-%{version}.tar.gz
+BuildArch: noarch
+
+Requires: python-plusdeck
+
+%description
+
+
+%prep
+%autosetup
+
+
+%build
+tar -xzf %{SOURCE0}
+
+
+%install
+mkdir -p %{buildroot}%{_libdir}/systemd/system
+install -p -m 644 systemd/plusdeck.service %{buildroot}%{_libdir}/systemd/system
+
+
+%check
+
+
+%files
+%{_libdir}/systemd/system/plusdeck.service
+
+%changelog

--- a/plusdeck.spec.tmpl
+++ b/plusdeck.spec.tmpl
@@ -1,0 +1,35 @@
+Name: plusdeck
+Version: {{ .Env.VERSION }}
+Release: {{ .Env.PATCH }}%{?dist}
+License: MPL-2.0
+Summary: Serial client and Linux service for Plus Deck 2C PC Cassette Deck
+
+URL: https://github.com/jfhbrook/plusdeck
+Source0: %{name}-%{version}.tar.gz
+BuildArch: noarch
+
+Requires: python-plusdeck
+
+%description
+
+
+%prep
+%autosetup
+
+
+%build
+tar -xzf %{SOURCE0}
+
+
+%install
+mkdir -p %{buildroot}%{_libdir}/systemd/system
+install -p -m 644 systemd/plusdeck.service %{buildroot}%{_libdir}/systemd/system
+
+
+%check
+
+
+%files
+%{_libdir}/systemd/system/plusdeck.service
+
+%changelog

--- a/plusdeck.spec.tmpl
+++ b/plusdeck.spec.tmpl
@@ -1,6 +1,6 @@
 Name: plusdeck
 Version: {{ .Env.VERSION }}
-Release: {{ .Env.PATCH }}%{?dist}
+Release: {{ .Env.RELEASE }}%{?dist}
 License: MPL-2.0
 Summary: Serial client and Linux service for Plus Deck 2C PC Cassette Deck
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "2.0.0"
 authors = [
   {name = "Josh Holbrook", email = "josh.holbrook@gmail.com"}
 ]
-description = "Serial client for Plus Deck 2C PC Cassette Deck"
+description = "Serial client and Linux service for Plus Deck 2C PC Cassette Deck"
 readme = "README.md"
 keywords = []
 license = { text = "MIT" }

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+VERSION="${1}"
+
+tar -czf "plusdeck-${VERSION}.tar.gz" \
+  CHANGELOG.md \
+  LICENSE \
+  Player.ipynb \
+  README.md \
+  docs \
+  plusdeck \
+  plusdeck.spec \
+  pyproject.toml \
+  pytest.ini \
+  requirements.txt \
+  requirements_dev.txt \
+  setup.cfg \
+  systemd \
+  tests \
+  tox.ini \
+  typings \
+  uv.lock

--- a/scripts/changelog-entry.py
+++ b/scripts/changelog-entry.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+import re
+import sys
+
+VERSION = sys.argv[1]
+
+TITLE_RE = r"\d{4}\/\d{2}\/\d{2} Version (\d+\.\d+\.\d+)"
+
+found = False
+changelog = ""
+
+with open("CHANGELOG.md", "r") as f:
+    it = iter(f)
+    try:
+        while True:
+            line = next(it)
+            m = re.findall(TITLE_RE, line)
+            if not found and m and m[0] == VERSION:
+                found = True
+                # Consume ----- line
+                next(it)
+            elif m:
+                # Found next entry
+                break
+            elif found:
+                changelog += line
+            else:
+                continue
+    except StopIteration:
+        pass
+
+if not found:
+    raise Exception(f"Could not find changelog entry for {VERSION}")
+
+print(changelog.strip())

--- a/scripts/changelog-entry.py
+++ b/scripts/changelog-entry.py
@@ -18,8 +18,7 @@ with open("CHANGELOG.md", "r") as f:
             m = re.findall(TITLE_RE, line)
             if not found and m and m[0] == VERSION:
                 found = True
-                # Consume ----- line
-                next(it)
+                changelog += line
             elif m:
                 # Found next entry
                 break

--- a/scripts/generate-spec.sh
+++ b/scripts/generate-spec.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+VERSION="${1}"
+PATCH="${2}"
+
+export VERSION
+export PATCH
+
+gomplate -f ./plusdeck.spec.tmpl -o plusdeck.spec

--- a/scripts/generate-spec.sh
+++ b/scripts/generate-spec.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 VERSION="${1}"
-PATCH="${2}"
+RELEASE="${2}"
 
 export VERSION
-export PATCH
+export RELEASE
 
 gomplate -f ./plusdeck.spec.tmpl -o plusdeck.spec

--- a/scripts/is-dirty.sh
+++ b/scripts/is-dirty.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+LINES="$(git status --porcelain)"
+
+echo "${LINES}" 1>&2
+
+[ -z "${LINES}" ]

--- a/scripts/is-main-branch.sh
+++ b/scripts/is-main-branch.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+
+echo "${BRANCH}" 1>&2
+
+[[ "${BRANCH}" == main ]]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,20 +3,7 @@
 VERSION="${1}"
 PATCH="${2}"
 
-NOTES=''
-TAKE_NOTES=''
-
-while read line; do
-  if [[ "${line}" == '%changelog' ]]; then
-    TAKE_NOTES=1
-  elif [ -n "${TAKE_NOTES}" ]; then
-    if [ -z "${line}" ]; then
-      break
-    fi
-    NOTES="${NOTES}
-${line}"
-  fi
-done < plusdeck.spec
+NOTES="$(./scripts/changelog-entry.py "${VERSION}")"
 
 gh release create "plusdeck-${VERSION}-${PATCH}" \
   -t "plusdeck v${VERSION}" \

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+VERSION="${1}"
+PATCH="${2}"
+
+NOTES=''
+TAKE_NOTES=''
+
+while read line; do
+  if [[ "${line}" == '%changelog' ]]; then
+    TAKE_NOTES=1
+  elif [ -n "${TAKE_NOTES}" ]; then
+    if [ -z "${line}" ]; then
+      break
+    fi
+    NOTES="${NOTES}
+${line}"
+  fi
+done < plusdeck.spec
+
+gh release create "plusdeck-${VERSION}-${PATCH}" \
+  -t "plusdeck v${VERSION}" \
+  -n "${NOTES}" \
+  "plusdeck-${VERSION}.tar.gz"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 VERSION="${1}"
-PATCH="${2}"
+RELEASE="${2}"
 
 NOTES="$(./scripts/changelog-entry.py "${VERSION}")"
 
-gh release create "plusdeck-${VERSION}-${PATCH}" \
+gh release create "plusdeck-${VERSION}-${RELEASE}" \
   -t "plusdeck v${VERSION}" \
   -n "${NOTES}" \
   "plusdeck-${VERSION}.tar.gz"

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+
+import toml
+
+with open("pyproject.toml", "r") as f:
+    project = toml.load(f)
+
+    print(project["project"]["version"])

--- a/systemd/plusdeck.service
+++ b/systemd/plusdeck.service
@@ -6,3 +6,4 @@ Type=dbus
 BusName=org.jfhbrook.plusdeck
 ExecStart=/usr/bin/plusdeckd
 Restart=on-failure
+

--- a/systemd/plusdeck.service
+++ b/systemd/plusdeck.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Plus Deck 2C PC Cassette Deck
+
+[Service]
+Type=dbus
+BusName=org.jfhbrook.plusdeck
+ExecStart=/usr/bin/plusdeckd
+Restart=on-failure


### PR DESCRIPTION
This PR does a lot of things:

1. Adds a systemd unit file
2. Sets up a `plusdeck` root RPM package spec
3. Sets up COPR specs for `plusdeck` and `python-plusdeck` packages
4. Tags/pushes release with Tito
5. Creates GitHub release
6. Applies and builds COPR packages

This is basically done. I'll go ahead and merge it when I'm ready to publish `3.0.0`. I'll use a major version because the root COPR package has changed.

**Remember to delete the `python-plusdeck.yml` file from the the `public` repo!**